### PR TITLE
Add currency_pairs api

### DIFF
--- a/lib/zaif.rb
+++ b/lib/zaif.rb
@@ -62,6 +62,18 @@ module Zaif
             return json
         end
 
+        # Get currency pairs of *currency_code* / *counter_currency_code*.
+        # @param [String]  currency_code Base     currency code
+        # @param [String]  counter_currency_code  Counter currency code
+        def get_currency_pairs(currency_code, counter_currency_code = "jpy")
+            currency_pair = currency_code
+            unless currency_code=='all'
+              currency_pair += "_" + counter_currency_code
+            end
+            json = get_ssl(@zaif_public_url + "currency_pairs/" + currency_pair)
+            return json
+        end
+        
         #
         # Trade API
         #


### PR DESCRIPTION
http://techbureau-api-document.readthedocs.io/ja/latest/public/2_individual/2_currency_pairs.html

### Example: get data of "btc_jpy"

```
get_currency_pairs("btc","jpy")
get_currency_pairs("btc")
```
return
```
[
    {
        "name": "BTC/JPY",
        "title": "BTC/JPY",
        "currency_pair": "btc_jpy",
        "description": "\u30d3\u30c3\u30c8\u30b3\u30a4\u30f3\u30fb\u65e5\u672c\u5186\u306e\u53d6\u5f15\u3092\u884c\u3046\u3053\u3068\u304c\u3067\u304d\u307e\u3059",
        "is_token": false,
        "event_number": 0,
        "item_unit_min": 0.0001,
        "item_unit_step": 0.0001,
        "aux_unit_min": 5.0,
        "aux_unit_step": 5.0,
        "seq": 0,
        "aux_japanese": "\u65e5\u672c\u5186",
        "item_japanese": "\u30d3\u30c3\u30c8\u30b3\u30a4\u30f3",
        "aux_unit_point": 0
    }
]
```

### Example: get all pairs

```
get_currency_pairs("all")
```
